### PR TITLE
Add support for nitrogen as well as feh for setting wallpaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ a random image from the specified subreddits. If you have pywal it also can set 
 ![Preview](preview.png)
 
 ## Requirements
-This script is made to work with ```feh``` or KDE, having one of those is a requirement. Currently it does not support GNOME out of the box since it automatically 
+This script is made to work with ```feh```, ```nitrogen```  or KDE, having one of those is a requirement. Currently it does not support GNOME out of the box since it automatically
 overrides feh's defaults. If you want to use the -p flag you will have to have ```pywal``` installed.
 
 ## Install
@@ -16,7 +16,7 @@ cd styli.sh
 ./styli.sh
 ```
 
-## Usage 
+## Usage
 ```
 # To set a random 1920x1080 background
 $ ./styli.sh
@@ -27,7 +27,7 @@ $ ./styli.sh -w 2560
 $ ./styli.sh -h 1440
 
 # To set a wallpaper based on a search term
-$ ./styli.sh -s island 
+$ ./styli.sh -s island
 $ ./styli.sh -s "sea sunset"
 $ ./styli.sh -s sea -w 1080
 
@@ -41,7 +41,7 @@ $ ./styli.sh -r wallpaperdump
 
 # To use the builtin feh --bg options
 $ ./styli.sh -b <option>
-$ ./styli.sh -b bg-scale -r widescreen-wallpaper 
+$ ./styli.sh -b bg-scale -r widescreen-wallpaper
 
 # To add custom feh flags
 $ ./styli.sh -c <flags>
@@ -50,7 +50,13 @@ $ ./styli.sh -c --no-xinerama -r widescreen-wallpaper
 # To automatically set the terminal colors
 $ ./styli.sh -p
 
-# Choose a random background from a directory 
+# To use nitrogen instead of feh
+$ ./styli.sh -n
+
+# To update > 1 screens using nitrogen
+$ ./styli.sh -n -m <number_of_screens>
+
+# Choose a random background from a directory
 $ ./styli.sh -d /path/to/dir
 ```
 ##KDE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Styli.sh - Wallpaper switching on feh and KDE made easy
+# Styli.sh - Wallpaper switching on feh, nitrogen and KDE made easy
 
 Stily.sh is a Bash script that aims to automate the tedious process of finding new wallpapers, downloading and switching them via the configs. **Styly.sh** can search for specific wallpapers from unsplash or download
 a random image from the specified subreddits. If you have pywal it also can set automatically your terminal colors.

--- a/styli.sh
+++ b/styli.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 link="https://source.unsplash.com/random/"
+
 if [ -z ${XDG_CONFIG_HOME+x} ]
 then
     XDG_CONFIG_HOME="${HOME}/.config"
@@ -18,6 +19,7 @@ if [ ! -d "${cachedir}" ]
 then
     mkdir -p "${cachedir}"
 fi
+
 reddit(){
     useragent="thevinter"
     timeout=60
@@ -65,8 +67,24 @@ reddit(){
     ext=`echo -n "${target_url##*.}"|cut -d '?' -f 1`
     newname=`echo $target_name | sed "s/^\///;s/\// /g"`_"$subreddit"_$target_id.$ext
     wget -T $timeout -U "$useragent" --no-check-certificate -q -P down -O "${cachedir}/wallpaper.jpg" $target_url &>/dev/null
-
 }
+
+unsplash() {
+  local search="${search// /_}"
+  if [ ! -z $height ] || [ ! -z $width ]; then
+      link="${link}${width}x${height}";
+  else
+      link="${link}1920x1080";
+  fi
+
+  if [ ! -z $search ]
+  then
+      link="${link}/?${search}"
+  fi
+
+  wget -q -O "${cachedir}/wallpaper.jpg" $link
+}
+
 usage(){
     echo "Usage: styli.sh [-s | --search <string>]
                           [-h | --height <height>]
@@ -78,15 +96,110 @@ usage(){
                           [-p | --termcolor]
                           [-d | --directory]
                           [-k | --kde]
+                          [-m | --monitors <monitor count (nitrogen)>]
+                          [-n | --nitrogen]
                           "
     exit 2
 }
+
+pywal_cmd() {
+  if [ $pywal -eq 1 ]; then
+      wal -c
+      wal -i "${cachedir}/wallpaper.jpg" -n
+  fi
+}
+
+nitrogen_cmd() {
+  for ((monitor=0; monitor < $monitors; monitor++))
+  do
+      local nitrogen=(nitrogen --save --head=${monitor})
+
+      if [ ! -z $bgtype ]; then
+          if [ $bgtype == 'bg-center' ]; then
+              nitrogen+=(--set-centered)
+          fi
+          if [ $bgtype == 'bg-fill' ]; then
+              nitrogen+=(--set-zoom-fill)
+          fi
+          if [ $bgtype == 'bg-max' ]; then
+              nitrogen+=(--set-zoom)
+          fi
+          if [ $bgtype == 'bg-scale' ]; then
+              nitrogen+=(--set-scaled)
+          fi
+          if [ $bgtype == 'bg-tile' ]; then
+              nitrogen+=(--set-tiled)
+          fi
+      else
+          nitrogen+=(--set-scaled)
+      fi
+
+      if [ ! -z $custom ]; then
+          nitrogen+=($custom)
+      fi
+
+      if [ ! -z $dir ]; then
+          nitrogen+=(--random $dir)
+      else
+	        nitrogen+=("${cachedir}/wallpaper.jpg")
+      fi
+
+      "${nitrogen[@]}"
+  done
+}
+
+kde_cmd() {
+	cp "${cachedir}/wallpaper.jpg" "${cachedir}/tmp.jpg"
+    qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \"org.kde.image\";d.currentConfigGroup = Array(\"Wallpaper\", \"org.kde.image\", \"General\");d.writeConfig(\"Image\", \"file:${cachedir}/tmp.jpg\")}"
+	qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \"org.kde.image\";d.currentConfigGroup = Array(\"Wallpaper\", \"org.kde.image\", \"General\");d.writeConfig(\"Image\", \"file:${cachedir}/wallpaper.jpg\")}"
+    rm "${cachedir}/tmp.jpg"
+}
+
+feh_cmd() {
+  local feh=(feh)
+  if [ ! -z $bgtype ]; then
+      if [ $bgtype == 'bg-center' ]; then
+          feh+=(--bg-center)
+      fi
+      if [ $bgtype == 'bg-fill' ]; then
+          feh+=(--bg-fill)
+      fi
+      if [ $bgtype == 'bg-max' ]; then
+          feh+=(--bg-max)
+      fi
+      if [ $bgtype == 'bg-scale' ]; then
+          feh+=(--bg-scale)
+      fi
+      if [ $bgtype == 'bg-tile' ]; then
+          feh+=(--bg-tile)
+      fi
+  else
+	  feh+=(--bg-scale)
+  fi
+
+  if [ ! -z $custom ]; then
+      feh+=($custom)
+  fi
+
+  if [ ! -z $dir ]; then
+    feh+=(--randomize $dir)
+  else
+	  feh+=("${cachedir}/wallpaper.jpg")
+  fi
+
+  "${feh[@]}"
+}
+
 pywal=0
 kde=false
-PARSED_ARGUMENTS=$(getopt -a -n $0 -o h:w:s:l:b:r:c:d:pk --long search:,height:,width:,fehbg:,fehopt:,subreddit:,directory:,termcolor:,kde -- "$@")
+nitrogen=false
+monitors=1
+
+PARSED_ARGUMENTS=$(getopt -a -n $0 -o h:w:s:l:b:r:c:d:m:pkn --long search:,height:,width:,fehbg:,fehopt:,subreddit:,directory:,monitors:,termcolor:,kde,nitrogen -- "$@")
 VALID_ARGUMENTS=$?
 if [ "$VALID_ARGUMENTS" != "0" ]; then
     usage
+    exit
 fi
 while :
 do
@@ -98,75 +211,30 @@ do
         -l | --link)      link=${2} ; shift 2 ;;
         -r | --subreddit) sub=${2} ; shift 2 ;;
         -c | --fehopt)    custom=${2} ; shift 2 ;;
+        -m | --monitors)  monitors=${2} ; shift 2 ;;
+        -n | --nitrogen)  nitrogen=true ; shift ;;
         -d | --directory) dir=${2} ; shift 2 ;;
         -p | --termcolor) pywal=1 ; shift ;;
-        -k | --kde) kde=true ; shift ;;
+        -k | --kde) 	  kde=true ; shift ;;
         -- | '') shift; break ;;
         *) echo "Unexpected option: $1 - this should not happen." ; usage ;;
     esac
 done
-feh=(feh)
-search="${search// /_}"
-if [ ! -z $bgtype ]; then
-    if [ $bgtype == 'bg-center' ]; then
-        feh+=(--bg-center)
-    fi
-    if [ $bgtype == 'bg-fill' ]; then
-        feh+=(--bg-fill)
-    fi
-    if [ $bgtype == 'bg-max' ]; then
-        feh+=(--bg-max)
-    fi
-    if [ $bgtype == 'bg-scale' ]; then
-        feh+=(--bg-scale)
-    fi
-    if [ $bgtype == 'bg-tile' ]; then
-        feh+=(--bg-tile)
-    fi
-else
-    feh+=(--bg-scale)
-fi
-if [ ! -z $custom ]; then
-    feh+=($custom)
-fi
-if [ ! -z $dir ]; then
-    feh+=(--randomize $dir)
-    "${feh[@]}"
-else
-    if [ $link = "reddit" ] || [ ! -z $sub ]
-    then
-        reddit "$sub"
-        feh+=("${cachedir}/wallpaper.jpg")
-        "${feh[@]}"
-        if [ $pywal -eq 1 ]; then
-            wal -c 
-            wal -i "${cachedir}/wallpaper.jpg" -n
-        fi 
-    else
-        if [ ! -z $height ] || [ ! -z $width ]; then
-            link="${link}${width}x${height}";
-        else
-            link="${link}1920x1080";
-        fi
-        if [ ! -z $search ]
-        then
-            link="${link}/?${search}"
-        fi
-        wget -q -O "${cachedir}/wallpaper.jpg" "${link}"
 
-        if [ $kde = true ]; then
-            cp "${cachedir}/wallpaper.jpg" "${cachedir}/tmp.jpg"
-            qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \"org.kde.image\";d.currentConfigGroup = Array(\"Wallpaper\", \"org.kde.image\", \"General\");d.writeConfig(\"Image\", \"file:${cachedir}/tmp.jpg\")}"
-            qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "var allDesktops = desktops();print (allDesktops);for (i=0;i<allDesktops.length;i++) {d = allDesktops[i];d.wallpaperPlugin = \"org.kde.image\";d.currentConfigGroup = Array(\"Wallpaper\", \"org.kde.image\", \"General\");d.writeConfig(\"Image\", \"file:${cachedir}/wallpaper.jpg\")}"
-            rm "${cachedir}/tmp.jpg"
-        else
-            feh+=("${cachedir}/wallpaper.jpg")
-            "${feh[@]}"
-        fi
-
-        if [ $pywal -eq 1 ]; then
-            wal -c 
-            wal -i "${cachedir}/wallpaper.jpg" -n
-        fi
-    fi
+if [ -z $dir ]; then
+  if [ $link = "reddit" ] || [ ! -z $sub ]; then
+	  reddit "$sub"
+  else
+	  unsplash
+  fi
 fi
+
+if [ $kde = true ]; then
+	kde_cmd
+elif [ $nitrogen = true ]; then
+	nitrogen_cmd
+else
+	feh_cmd
+fi
+
+pywal_cmd


### PR DESCRIPTION
I saw this script on the DistroTube channel and thought it was great, I had something I'd done using nitrogen that was very customized to my setup and I thought it might be worthwhile to add nitrogen support to this project.

The change adds a -n flag which will build the command to set the wallpaper using nitrogen instead of feh. As nitrogen behaves slightly differently when handling multiple screens it uses a second argument -m (--monitors) to specify the number of screens to set the wallpaper for.

As there was some duplication on the initial attempt, I moved the unsplash and pywal commands into separate functions.

Hope you find this useful!
