### PR TITLE
Fix unsplash search term for multiple words

### DIFF
--- a/styli.sh
+++ b/styli.sh
@@ -184,7 +184,7 @@ reddit() {
 }
 
 unsplash() {
-    local SEARCH="${SEARCH// /_}"
+    local SEARCH="${SEARCH// /+}"
     if [ -n "$HEIGHT" ] || [ -n "$WIDTH" ]; then
         LINK="${LINK}${WIDTH}x${HEIGHT}" # dont remove {} from variables
     else


### PR DESCRIPTION
Currently, if we use unsplash for multiple words, it doesn't work because of incorrect handling of spaces.
This PR fixes the spaces to be replaced by `+` sign which is URL encoding for ` `.