### PR TITLE
🩹 Fix grep usage in xfce_cmd()

### DIFF
--- a/styli.sh
+++ b/styli.sh
@@ -365,7 +365,7 @@ xfce_cmd() {
     xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitor0/image-path -n -t string -s ~/Pictures/1.jpeg
     xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitorLVDS1/workspace0/last-image -n -t string -s ~/Pictures/1.jpeg
 
-    for i in $(xfconf-query -c xfce4-desktop -p /backdrop -l | grep -E "screen.*/monitor.*image-path$" -e "screen.*/monitor.*/last-image$"); do
+    for i in $(xfconf-query -c xfce4-desktop -p /backdrop -l | grep -E -e "screen.*/monitor.*image-path$" -e "screen.*/monitor.*/last-image$"); do
         xfconf-query -c xfce4-desktop -p "$i" -n -t string -s "$WALLPAPER"
         xfconf-query -c xfce4-desktop -p "$i" -s "$WALLPAPER"
     done


### PR DESCRIPTION
This Pull Request fixes the `grep` usage in `xfce_cmd()`, a regression introduced in https://github.com/thevinter/styli.sh/commit/f582b4f28b1ac5b7b087dd1798d0691e8f43f70d#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR363

- fixes #49 