### PR TITLE
Added swww support and Shifted to Picsum from unsplash and added an install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Install script for styli.sh
+
+set -e
+
+SCRIPT_NAME="styli.sh"
+INSTALL_DIR="/usr/local/bin"
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$SCRIPT_NAME"
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+    echo "Please run as root (e.g., with sudo)."
+    exit 1
+fi
+
+# Check if styli.sh exists
+if [[ ! -f "$SCRIPT_PATH" ]]; then
+    echo "Error: $SCRIPT_NAME not found in $(dirname "$0")"
+    exit 1
+fi
+
+# Make script executable
+chmod +x "$SCRIPT_PATH"
+
+# Copy to /usr/local/bin
+cp "$SCRIPT_PATH" "$INSTALL_DIR/"
+
+echo "$SCRIPT_NAME installed to $INSTALL_DIR."
+echo "You can now run 'styli.sh' from anywhere."

--- a/styli.sh
+++ b/styli.sh
@@ -7,6 +7,7 @@
 
 
 LINK="https://source.unsplash.com/random/"
+PICSUM_LINK="https://picsum.photos/"
 
 if [ -z ${XDG_CONFIG_HOME+x} ]; then
     XDG_CONFIG_HOME="$HOME/.config"
@@ -183,6 +184,20 @@ reddit() {
     wget -T $TIMEOUT -U "$USERAGENT" --no-check-certificate -q -P down -O "$WALLPAPER" "$TARGET_URL" &>/dev/null
 }
 
+picsum() {
+    if [ -n "$HEIGHT" ] || [ -n "$WIDTH" ]; then
+        LINK="${PICSUM_LINK}${WIDTH}/${HEIGHT}" # dont remove {} from variables
+    else
+        LINK="${PICSUM_LINK}/1920/1080"
+    fi
+
+    if [ -n "$SEARCH" ]; then
+        LINK="${PICSUM_LINK}/?${SEARCH}"
+    fi
+
+    wget -q -O "$WALLPAPER" "$LINK"
+}
+
 unsplash() {
     local SEARCH="${SEARCH// /+}"
     if [ -n "$HEIGHT" ] || [ -n "$WIDTH" ]; then
@@ -321,6 +336,10 @@ hyprpaper_cmd() {
     hyprctl hyprpaper wallpaper "eDP-1,$WALLPAPER"
 }
 
+swww_cmd() {
+    swww img -o eDP-1 "$WALLPAPER"
+}
+
 nitrogen_cmd() {
     for ((monitor = 0; monitor < "$MONITORS"; monitor++)); do
         local NITROGEN_ARR=(nitrogen --save --head="$monitor")
@@ -422,6 +441,7 @@ GNOME=false
 NITROGEN=false
 SWAY=false
 HYPRPAPER=false
+SWWW=false
 MONITORS=1
 # SC2034
 PARSED_ARGUMENTS=$(getopt -a -n "$0" -o h:w:s:l:b:r:a:c:d:m:pLknxgy:sa --long search:,height:,width:,fehbg:,fehopt:,artist:,subreddit:,directory:,monitors:,termcolor:,lighwal:,kde,nitrogen,xfce,gnome,sway,save -- "$@")
@@ -505,6 +525,10 @@ while :; do
         SWAY=true
         shift
         ;;
+    -sw | --swww)
+        SWWW=true
+	shift
+	;;
     -hp | --hyprpaper)
       HYPRPAPER=true
       shift
@@ -529,7 +553,8 @@ elif [ "$LINK" = "deviantart" ] || [ -n "$ARTIST" ]; then
 elif [ -n "$SAVE" ]; then
     save_cmd
 else
-    unsplash
+    echo $WALLPAPER
+    picsum
 fi
 
 type_check
@@ -546,6 +571,8 @@ elif [ "$SWAY" = true ]; then
     sway_cmd
 elif [ "$HYPRPAPER" = true ]; then
     hyprpaper_cmd
+elif [ "$SWWW" = true ]; then
+    swww_cmd
 else
     feh_cmd >/dev/null 2>&1
 fi


### PR DESCRIPTION
This pull request introduces a new installation script for `styli.sh` and adds several enhancements to its functionality, including support for a new image source (`picsum.photos`) and a new wallpaper setting command (`swww`). Below is a summary of the most important changes:

### New Installation Script:
* Added `install.sh`, a Bash script to install `styli.sh` to `/usr/local/bin`. It includes checks for root privileges, ensures the script exists, makes it executable, and copies it to the appropriate directory.

### Enhancements to Image Sources:
* Added support for `picsum.photos` as a new image source in `styli.sh`. This includes a new `picsum()` function that constructs the image URL based on optional height, width, and search parameters. [[1]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR10) [[2]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR187-R200) [[3]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aL532-R557)

### New Wallpaper Setting Command:
* Added support for `swww`, a wallpaper manager, with a new `swww_cmd()` function to set wallpapers. This includes a corresponding flag (`-sw | --swww`) and logic to handle it. [[1]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR339-R342) [[2]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR444) [[3]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR528-R531) [[4]](diffhunk://#diff-69a87c69809f32cc8d883aec422201110a15a3379cef90bb9e7d0815b295218aR574-R575)